### PR TITLE
Don't cancel the multicast interface context for a single failed write

### DIFF
--- a/multicast/multicast.go
+++ b/multicast/multicast.go
@@ -238,7 +238,6 @@ func (m *Multicast) advertise(intf *multicastInterface, conn net.PacketConn, add
 		)
 		if err != nil {
 			//m.log.Println("conn.WriteTo:", err)
-			intf.cancel()
 			continue
 		}
 	}


### PR DESCRIPTION
This seems to spam a lot of `Multicast discovery enabled` messages on unsuitable interfaces.

Should fix #5.