### PR TITLE
Add simulator uptime to the webpage

### DIFF
--- a/cmd/pineconesim/main.go
+++ b/cmd/pineconesim/main.go
@@ -249,6 +249,7 @@ func configureHTTPRouting(sim *simulator.Simulator) {
 			AvgStretch:          "TBD",
 			TreePathConvergence: "TBD",
 			SNEKPathConvergence: "TBD",
+			Uptime:              sim.Uptime().Round(time.Second),
 		}
 		if totalCount > 0 {
 			data.TreePathConvergence = fmt.Sprintf("%d%%", (dhtConvergence*100)/totalCount)
@@ -464,6 +465,7 @@ type PageData struct {
 	TreePathConvergence string
 	SNEKPathConvergence string
 	NodeInfo            *NodeInfo
+	Uptime              time.Duration
 }
 
 type NodeInfo struct {

--- a/cmd/pineconesim/page.html
+++ b/cmd/pineconesim/page.html
@@ -80,7 +80,7 @@
     <body>
         <div class="row" id="title">
             <div id="left">
-                <strong>Pinecone Simulator</strong> is running with {{.NodeCount}} nodes
+                <strong>Pinecone Simulator</strong> is running with {{.NodeCount}} nodes for {{.Uptime}}
             </div>
             <div id="right">
                 Topology view: 

--- a/cmd/pineconesim/simulator/simulator.go
+++ b/cmd/pineconesim/simulator/simulator.go
@@ -18,6 +18,7 @@ import (
 	"log"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/RyanCarrier/dijkstra"
 )
@@ -36,6 +37,7 @@ type Simulator struct {
 	snekPathConvergenceMutex sync.RWMutex
 	treePathConvergence      map[string]map[string]bool
 	treePathConvergenceMutex sync.RWMutex
+	startTime                time.Time
 }
 
 func NewSimulator(log *log.Logger) *Simulator {
@@ -46,6 +48,7 @@ func NewSimulator(log *log.Logger) *Simulator {
 		dists:               make(map[string]map[string]*Distance),
 		snekPathConvergence: make(map[string]map[string]bool),
 		treePathConvergence: make(map[string]map[string]bool),
+		startTime:           time.Now(),
 	}
 	return sim
 }
@@ -105,4 +108,8 @@ func (sim *Simulator) TreePathConvergence() map[string]map[string]bool {
 		}
 	}
 	return mapcopy
+}
+
+func (sim *Simulator) Uptime() time.Duration {
+	return time.Since(sim.startTime)
 }


### PR DESCRIPTION
This change adds the current simulator runtime value to the webpage.
The value is rounded to the nearest second to make it look clean.

The page title ends up looking like this:
**Pinecone Simulator** is running with 49 nodes for 14m41s 

Signed-off-by: `Devon Hudson <devonhudson@librem.one>`
