### PR TITLE
Use inboxes so that subscribers don't block node operations

### DIFF
--- a/cmd/pineconesim/simulator/event_queue.go
+++ b/cmd/pineconesim/simulator/event_queue.go
@@ -14,8 +14,6 @@
 
 package simulator
 
-import "errors"
-
 type EventQueue struct {
 	q chan SimEventMsg
 }
@@ -25,11 +23,7 @@ func (q *EventQueue) Insert(item SimEventMsg) {
 }
 
 func (q *EventQueue) Remove() (SimEventMsg, error) {
-	if len(q.q) > 0 {
-		item := <-q.q
-		return item, nil
-	}
-	return SimEventMsg{UpdateID: UnknownUpdate}, errors.New("Queue is empty")
+	return <-q.q, nil
 }
 
 func NewEventQueue(capacity int) *EventQueue {

--- a/cmd/pineconesim/simulator/nodes.go
+++ b/cmd/pineconesim/simulator/nodes.go
@@ -91,7 +91,7 @@ func (sim *Simulator) CreateNode(t string) error {
 }
 
 func (sim *Simulator) StartNodeEventHandler(t string) {
-	ch := make(chan events.Event, 10)
+	ch := make(chan events.Event)
 	handler := eventHandler{node: t, ch: ch}
 	go handler.Run(sim)
 	sim.nodes[t].Subscribe(ch)

--- a/router/api.go
+++ b/router/api.go
@@ -57,7 +57,9 @@ type PeerInfo struct {
 
 // Subscribe registers a subscriber to this node's events
 func (r *Router) Subscribe(ch chan<- events.Event) {
-	r._subscribers = append(r._subscribers, ch)
+	phony.Block(r, func() {
+		r._subscribers[ch] = &phony.Inbox{}
+	})
 }
 
 func (r *Router) Coords() types.Coordinates {

--- a/router/state.go
+++ b/router/state.go
@@ -123,7 +123,9 @@ func (s *state) _addPeer(conn net.Conn, public types.PublicKey, zone string, pee
 		new.reader.Act(nil, new._read)
 		new.writer.Act(nil, new._write)
 
-		s.r.publish(events.PeerAdded{Port: types.SwitchPortID(i), PeerID: new.public.String()})
+		s.r.Act(nil, func() {
+			s.r._publish(events.PeerAdded{Port: types.SwitchPortID(i), PeerID: new.public.String()})
+		})
 		return types.SwitchPortID(i), nil
 	}
 
@@ -134,7 +136,9 @@ func (s *state) _addPeer(conn net.Conn, public types.PublicKey, zone string, pee
 func (s *state) _removePeer(port types.SwitchPortID) {
 	peerID := s._peers[port].public.String()
 	s._peers[port] = nil
-	s.r.publish(events.PeerRemoved{Port: port, PeerID: peerID})
+	s.r.Act(nil, func() {
+		s.r._publish(events.PeerRemoved{Port: port, PeerID: peerID})
+	})
 }
 
 func (s *state) _setParent(peer *peer) {
@@ -144,8 +148,9 @@ func (s *state) _setParent(peer *peer) {
 	if peer != nil {
 		peerID = peer.public.String()
 	}
-
-	s.r.publish(events.TreeParentUpdate{PeerID: peerID})
+	s.r.Act(nil, func() {
+		s.r._publish(events.TreeParentUpdate{PeerID: peerID})
+	})
 }
 
 func (s *state) _setAscendingNode(node *virtualSnakeEntry) {
@@ -156,7 +161,9 @@ func (s *state) _setAscendingNode(node *virtualSnakeEntry) {
 		peerID = node.Origin.String()
 	}
 
-	s.r.publish(events.SnakeAscUpdate{PeerID: peerID})
+	s.r.Act(nil, func() {
+		s.r._publish(events.SnakeAscUpdate{PeerID: peerID})
+	})
 }
 
 func (s *state) _setDescendingNode(node *virtualSnakeEntry) {
@@ -167,7 +174,9 @@ func (s *state) _setDescendingNode(node *virtualSnakeEntry) {
 		peerID = node.PublicKey.String()
 	}
 
-	s.r.publish(events.SnakeDescUpdate{PeerID: peerID})
+	s.r.Act(nil, func() {
+		s.r._publish(events.SnakeDescUpdate{PeerID: peerID})
+	})
 }
 
 // _portDisconnected is called when a peer disconnects.


### PR DESCRIPTION
This PR does a couple things:

1. Gives each subscriber an inbox, so that we can queue blocking channel sends in a non-blocking fashion — this is important so that we don't block the router actors for any longer than we need to;
2. Fixes a bug where the `_subscribers` in the router was unprotected, as it wasn't previously an actor;
3. Updates `EventQueue.Remove` to just wait for something on the channel, instead of spinning, so that it isn't burning a full CPU core constantly.