### PR TITLE
Consolidated `Connect` function with `ConnectionOptions`

### DIFF
--- a/cmd/pinecone/main.go
+++ b/cmd/pinecone/main.go
@@ -67,7 +67,11 @@ func main() {
 				panic(err)
 			}
 
-			if _, err := pineconeRouter.AuthenticatedConnect(conn, "", router.PeerTypeRemote, true); err != nil {
+			if _, err := pineconeRouter.Connect(
+				conn,
+				router.ConnectionURI(*connect),
+				router.ConnectionPeerType(router.PeerTypeRemote),
+			); err != nil {
 				panic(err)
 			}
 
@@ -89,7 +93,11 @@ func main() {
 				panic(err)
 			}
 
-			if _, err := pineconeRouter.AuthenticatedConnect(conn, "", router.PeerTypeRemote, true); err != nil {
+			if _, err := pineconeRouter.Connect(
+				conn,
+				router.ConnectionURI(conn.RemoteAddr().String()),
+				router.ConnectionPeerType(router.PeerTypeRemote),
+			); err != nil {
 				panic(err)
 			}
 

--- a/cmd/pineconeip/main.go
+++ b/cmd/pineconeip/main.go
@@ -103,7 +103,11 @@ func main() {
 				panic(err)
 			}
 
-			port, err := pineconeRouter.AuthenticatedConnect(conn, "", router.PeerTypeRemote, true)
+			port, err := pineconeRouter.Connect(
+				conn,
+				router.ConnectionURI(*connect),
+				router.ConnectionPeerType(router.PeerTypeRemote),
+			)
 			if err != nil {
 				panic(err)
 			}
@@ -125,7 +129,11 @@ func main() {
 				panic(err)
 			}
 
-			port, err := pineconeRouter.AuthenticatedConnect(conn, "", router.PeerTypeRemote, true)
+			port, err := pineconeRouter.Connect(
+				conn,
+				router.ConnectionURI(conn.RemoteAddr().String()),
+				router.ConnectionPeerType(router.PeerTypeRemote),
+			)
 			if err != nil {
 				panic(err)
 			}

--- a/cmd/pineconesim/simulator/links.go
+++ b/cmd/pineconesim/simulator/links.go
@@ -58,7 +58,11 @@ func (sim *Simulator) ConnectNodes(a, b string) error {
 			panic(err)
 		}
 		sc := &util.SlowConn{Conn: c, ReadJitter: 5 * time.Millisecond}
-		if _, err := nb.AuthenticatedConnect(sc, "sim", router.PeerTypeRemote, false); err != nil {
+		if _, err := nb.Connect(
+			sc,
+			router.ConnectionKeepalives(false),
+			router.PeerTypeRemote,
+		); err != nil {
 			return fmt.Errorf("nb.AuthenticatedConnect: %w", err)
 		}
 		register(sc)
@@ -67,12 +71,22 @@ func (sim *Simulator) ConnectNodes(a, b string) error {
 		pa = &util.SlowConn{Conn: pa, ReadJitter: 5 * time.Millisecond}
 		pb = &util.SlowConn{Conn: pb, ReadJitter: 5 * time.Millisecond}
 		go func() {
-			if _, err := na.Connect(pa, nb.PublicKey(), "sim", router.PeerTypeRemote, false); err != nil {
+			if _, err := na.Connect(
+				pa,
+				router.ConnectionPublicKey(nb.PublicKey()),
+				router.ConnectionKeepalives(false),
+				router.PeerTypeRemote,
+			); err != nil {
 				return
 			}
 		}()
 		go func() {
-			if _, err := nb.Connect(pb, na.PublicKey(), "sim", router.PeerTypeRemote, false); err != nil {
+			if _, err := nb.Connect(
+				pb,
+				router.ConnectionPublicKey(na.PublicKey()),
+				router.ConnectionKeepalives(false),
+				router.PeerTypeRemote,
+			); err != nil {
 				return
 			}
 		}()

--- a/cmd/pineconesim/simulator/nodes.go
+++ b/cmd/pineconesim/simulator/nodes.go
@@ -79,7 +79,11 @@ func (sim *Simulator) CreateNode(t string) error {
 				if err := c.SetLinger(0); err != nil {
 					panic(err)
 				}
-				if _, err = n.AuthenticatedConnect(c, "sim", router.PeerTypeRemote, true); err != nil {
+				if _, err = n.Connect(
+					c,
+					router.ConnectionPeerType(router.PeerTypeRemote),
+					router.ConnectionKeepalives(true),
+				); err != nil {
 					continue
 				}
 			}

--- a/multicast/multicast.go
+++ b/multicast/multicast.go
@@ -172,7 +172,11 @@ func (m *Multicast) accept(listener net.Listener) {
 				m.log.Println("m.tcpSocketOptions: %w", err)
 			}
 
-			if _, err := m.r.AuthenticatedConnect(tcpconn, tcpaddr.Zone, router.PeerTypeMulticast, true); err != nil {
+			if _, err := m.r.Connect(
+				tcpconn,
+				router.ConnectionZone(tcpaddr.Zone),
+				router.PeerTypeMulticast,
+			); err != nil {
 				//m.log.Println("m.s.AuthenticatedConnect:", err)
 				_ = conn.Close()
 			}
@@ -332,7 +336,11 @@ func (m *Multicast) listen(intf *multicastInterface, conn net.PacketConn, srcadd
 				m.log.Println("m.tcpSocketOptions: %w", err)
 			}
 
-			if _, err := m.r.AuthenticatedConnect(tcpconn, udpaddr.Zone, router.PeerTypeMulticast, true); err != nil {
+			if _, err := m.r.Connect(
+				tcpconn,
+				router.ConnectionZone(udpaddr.Zone),
+				router.PeerTypeMulticast,
+			); err != nil {
 				m.log.Println("m.s.AuthenticatedConnect:", err)
 				_ = conn.Close()
 			}

--- a/router/peer.go
+++ b/router/peer.go
@@ -36,7 +36,7 @@ const peerKeepaliveInterval = time.Second * 3
 const peerKeepaliveTimeout = time.Second * 5
 
 const (
-	PeerTypeMulticast int = iota
+	PeerTypeMulticast ConnectionPeerType = iota
 	PeerTypeBluetooth
 	PeerTypeRemote
 )
@@ -54,6 +54,7 @@ type peer struct {
 	context    context.Context    // Not mutated after peer setup.
 	cancel     context.CancelFunc // Not mutated after peer setup.
 	conn       net.Conn           // Not mutated after peer setup.
+	uri        string             // Not mutated after peer setup.
 	zone       string             // Not mutated after peer setup.
 	peertype   int                // Not mutated after peer setup.
 	public     types.PublicKey    // Not mutated after peer setup.

--- a/router/state.go
+++ b/router/state.go
@@ -106,6 +106,7 @@ func (s *state) _addPeer(conn net.Conn, public types.PublicKey, uri, zone string
 			port:       types.SwitchPortID(i),
 			conn:       conn,
 			public:     public,
+			uri:        uri,
 			zone:       zone,
 			peertype:   peertype,
 			keepalives: keepalives,

--- a/router/state.go
+++ b/router/state.go
@@ -92,7 +92,7 @@ func (s *state) _maintainSnakeIn(d time.Duration) {
 }
 
 // _addPeer creates a new Peer and adds it to the switch in the next available port
-func (s *state) _addPeer(conn net.Conn, public types.PublicKey, zone string, peertype int, keepalives bool) (types.SwitchPortID, error) {
+func (s *state) _addPeer(conn net.Conn, public types.PublicKey, uri, zone string, peertype int, keepalives bool) (types.SwitchPortID, error) {
 	var new *peer
 	for i, p := range s._peers {
 		if i == 0 || p != nil {


### PR DESCRIPTION
This PR merges the `Connect` and `AuthenticatedConnect` into a single function that takes one or more `ConnectionOptions` to supply information about the peer.

In cases where no `ConnectionPublicKey` is provided, `Connect` will automatically negotiate with the remote side. 

This also adds an option to store the connection URI, so that things like the iOS and Android demos can see if they are already connected to a configured peer. 

Finally, this adds a `Peers` function for getting peer information out of the router. 