### PR TITLE
Setup ACKs

### DIFF
--- a/router/peer.go
+++ b/router/peer.go
@@ -93,7 +93,7 @@ func (p *peer) send(f *types.Frame) bool {
 		fallthrough
 	case types.TypeVirtualSnakeBootstrap, types.TypeVirtualSnakeBootstrapACK:
 		fallthrough
-	case types.TypeVirtualSnakeSetup, types.TypeVirtualSnakeTeardown:
+	case types.TypeVirtualSnakeSetup, types.TypeVirtualSnakeSetupACK, types.TypeVirtualSnakeTeardown:
 		if p.proto == nil {
 			// The local peer doesn't have a protocol queue so we should check
 			// for nils to prevent panics.

--- a/router/version.go
+++ b/router/version.go
@@ -17,7 +17,8 @@ package router
 const (
 	capabilityLengthenedRootInterval = iota + 1
 	capabilityCryptographicSetups
+	capabilitySetupACKs
 )
 
 const ourVersion uint8 = 1
-const ourCapabilities uint32 = capabilityLengthenedRootInterval | capabilityCryptographicSetups
+const ourCapabilities uint32 = capabilityLengthenedRootInterval | capabilityCryptographicSetups | capabilitySetupACKs

--- a/types/virtualsnake.go
+++ b/types/virtualsnake.go
@@ -137,7 +137,7 @@ func (v *VirtualSnakeSetup) UnmarshalBinary(buf []byte) (int, error) {
 
 type VirtualSnakeSetupACK struct {
 	PathID    VirtualSnakePathID
-	SourceSig VirtualSnakePathSig
+	TargetSig VirtualSnakePathSig
 	Root
 }
 
@@ -153,7 +153,7 @@ func (v *VirtualSnakeSetupACK) MarshalBinary(buf []byte) (int, error) {
 		return 0, fmt.Errorf("v.RootSequence.MarshalBinary: %w", err)
 	}
 	offset += n
-	offset += copy(buf[offset:], v.SourceSig[:])
+	offset += copy(buf[offset:], v.TargetSig[:])
 	return offset, nil
 }
 
@@ -169,7 +169,7 @@ func (v *VirtualSnakeSetupACK) UnmarshalBinary(buf []byte) (int, error) {
 		return 0, fmt.Errorf("v.RootSequence.UnmarshalBinary: %w", err)
 	}
 	offset += l
-	offset += copy(v.SourceSig[:], buf[offset:])
+	offset += copy(v.TargetSig[:], buf[offset:])
 	return offset, nil
 }
 

--- a/types/virtualsnake.go
+++ b/types/virtualsnake.go
@@ -135,6 +135,44 @@ func (v *VirtualSnakeSetup) UnmarshalBinary(buf []byte) (int, error) {
 	return offset, nil
 }
 
+type VirtualSnakeSetupACK struct {
+	PathID    VirtualSnakePathID
+	SourceSig VirtualSnakePathSig
+	Root
+}
+
+func (v *VirtualSnakeSetupACK) MarshalBinary(buf []byte) (int, error) {
+	if len(buf) < VirtualSnakePathIDLength+ed25519.PublicKeySize+v.RootSequence.Length()+ed25519.SignatureSize {
+		return 0, fmt.Errorf("buffer too small")
+	}
+	offset := 0
+	offset += copy(buf[offset:], v.PathID[:])
+	offset += copy(buf[offset:], v.RootPublicKey[:])
+	n, err := v.RootSequence.MarshalBinary(buf[offset:])
+	if err != nil {
+		return 0, fmt.Errorf("v.RootSequence.MarshalBinary: %w", err)
+	}
+	offset += n
+	offset += copy(buf[offset:], v.SourceSig[:])
+	return offset, nil
+}
+
+func (v *VirtualSnakeSetupACK) UnmarshalBinary(buf []byte) (int, error) {
+	if len(buf) < VirtualSnakePathIDLength+ed25519.PublicKeySize+1+ed25519.SignatureSize {
+		return 0, fmt.Errorf("buffer too small")
+	}
+	offset := 0
+	offset += copy(v.PathID[:], buf[offset:])
+	offset += copy(v.RootPublicKey[:], buf[offset:])
+	l, err := v.RootSequence.UnmarshalBinary(buf[offset:])
+	if err != nil {
+		return 0, fmt.Errorf("v.RootSequence.UnmarshalBinary: %w", err)
+	}
+	offset += l
+	offset += copy(v.SourceSig[:], buf[offset:])
+	return offset, nil
+}
+
 type VirtualSnakeTeardown struct {
 	PathID VirtualSnakePathID
 }


### PR DESCRIPTION
This adds a new packet type — Setup ACK — and an "active" field to DHT routing table entries. A given path will only be activated upon receipt of a setup ACK packet from the remote side. Paths that are not activated after 5 seconds are torn down automatically.