### PR TITLE
Enable keepalives in `-sockets` mode on the connecting side

### DIFF
--- a/cmd/pineconesim/simulator/links.go
+++ b/cmd/pineconesim/simulator/links.go
@@ -63,7 +63,7 @@ func (sim *Simulator) ConnectNodes(a, b string) error {
 		sc := &util.SlowConn{Conn: c, ReadJitter: 5 * time.Millisecond}
 		if _, err := nb.Connect(
 			sc,
-			router.ConnectionKeepalives(false),
+			router.ConnectionKeepalives(true),
 			router.ConnectionPeerType(router.PeerTypeRemote),
 		); err != nil {
 			return fmt.Errorf("nb.AuthenticatedConnect: %w", err)


### PR DESCRIPTION
Keepalives are already enabled on the accepting side, and they have to be enabled on both sides, otherwise everything collapses with `i/o timeout`s.