### PR TITLE
Sim - add url anchors so refreshing returns to the same view

### DIFF
--- a/cmd/pineconesim/ui/main.js
+++ b/cmd/pineconesim/ui/main.js
@@ -69,3 +69,17 @@ function handleSimMessage(msg) {
 };
 
 ConnectToServer({url: window.origin.replace("http", "ws") + '/ws'}, handleSimMessage);
+
+function selectStartingNetwork() {
+    let selectionTabs = document.getElementsByClassName("netselect");
+    var hash = window.location.hash.substr(1);
+    if (hash != "") {
+        for (let i = 0; i < selectionTabs.length; i++) {
+            if (selectionTabs[i].id.includes(hash)) {
+                selectionTabs[i].click();
+                break;
+            }
+        }
+    }
+}
+selectStartingNetwork();

--- a/cmd/pineconesim/ui/modules/ui.js
+++ b/cmd/pineconesim/ui/modules/ui.js
@@ -80,20 +80,26 @@ function selectNetworkType(networkType) {
 
     this.className += " active";
 
+    let anchor = "";
     switch(this.id) {
     case "peerTopo":
-        graph.changeDataSet("peer");
+        anchor = "peer";
         break;
     case "snakeTopo":
-        graph.changeDataSet("snake");
+        anchor = "snake";
         break;
     case "treeTopo":
-        graph.changeDataSet("tree");
+        anchor = "tree";
         break;
     case "geographicTopo":
-        graph.changeDataSet("geographic");
+        anchor = "geographic";
         break;
+    default:
+        return;
     }
+
+    graph.changeDataSet(anchor);
+    window.location.href = "#" + anchor;
 }
 
 function setupNetworkSelection() {


### PR DESCRIPTION
Changes the sim to return to the previously viewed topology type on a refresh.