### PR TITLE
Fix simulator ping convergence

### DIFF
--- a/cmd/pineconesim/simulator/simulator.go
+++ b/cmd/pineconesim/simulator/simulator.go
@@ -17,6 +17,7 @@ package simulator
 import (
 	"crypto/ed25519"
 	"log"
+	"math"
 	"net"
 	"runtime"
 	"sync"
@@ -143,10 +144,10 @@ func (sim *Simulator) StartPinging(ping_period time.Duration) {
 				}
 				close(tasks)
 
-				numworkers := runtime.NumCPU() * 16
+				numWorkers := int(math.Min(12, float64(runtime.NumCPU())))
 				var wg sync.WaitGroup
-				wg.Add(numworkers)
-				for i := 0; i < numworkers; i++ {
+				wg.Add(numWorkers)
+				for i := 0; i < numWorkers; i++ {
 					go func() {
 						for pair := range tasks {
 							sim.log.Println("Tree ping from", pair.from, "to", pair.to)

--- a/router/packetconn.go
+++ b/router/packetconn.go
@@ -34,7 +34,7 @@ func (r *Router) newLocalPeer() *peer {
 		zone:     "local",
 		peertype: 0,
 		public:   r.public,
-		traffic:  newFairFIFOQueue(trafficBuffer),
+		traffic:  newFairFIFOQueue(trafficBuffer, r.log),
 	}
 	return peer
 }

--- a/router/queuefairfifo.go
+++ b/router/queuefairfifo.go
@@ -87,6 +87,7 @@ func (q *fairFIFOQueue) push(frame *types.Frame) bool {
 		// There is space in the queue
 		q.count++
 	default:
+		println("Queue is full - dropping a frame from the head of the queue")
 		// The queue is full - perform a head drop
 		<-q.queues[h]
 		q.dropped++

--- a/router/queuefairfifo.go
+++ b/router/queuefairfifo.go
@@ -25,6 +25,7 @@ import (
 const fairFIFOQueueSize = 16
 
 type fairFIFOQueue struct {
+	log     types.Logger
 	queues  map[uint16]chan *types.Frame // queue ID -> frame, map for randomness
 	num     uint16                       // how many queues should we have?
 	count   int                          // how many queued items in total?
@@ -35,8 +36,9 @@ type fairFIFOQueue struct {
 	mutex   sync.Mutex
 }
 
-func newFairFIFOQueue(num uint16) *fairFIFOQueue {
+func newFairFIFOQueue(num uint16, log types.Logger) *fairFIFOQueue {
 	q := &fairFIFOQueue{
+		log:    log,
 		offset: rand.Uint64(),
 		num:    num,
 	}
@@ -87,7 +89,7 @@ func (q *fairFIFOQueue) push(frame *types.Frame) bool {
 		// There is space in the queue
 		q.count++
 	default:
-		println("Queue is full - dropping a frame from the head of the queue")
+		q.log.Println("Queue is full - dropping a frame from the head of the queue")
 		// The queue is full - perform a head drop
 		<-q.queues[h]
 		q.dropped++

--- a/router/queuefifo.go
+++ b/router/queuefifo.go
@@ -22,6 +22,7 @@ import (
 )
 
 type fifoQueue struct {
+	log     types.Logger
 	max     int
 	entries []chan *types.Frame
 	mutex   sync.Mutex
@@ -29,8 +30,9 @@ type fifoQueue struct {
 
 const fifoNoMax = 0
 
-func newFIFOQueue(max int) *fifoQueue {
+func newFIFOQueue(max int, log types.Logger) *fifoQueue {
 	q := &fifoQueue{
+		log: log,
 		max: max,
 	}
 	q.reset()

--- a/router/queuefifo_test.go
+++ b/router/queuefifo_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestLimitedFIFO(t *testing.T) {
-	q := newFIFOQueue(5)
+	q := newFIFOQueue(5, nil)
 
 	// the actual allocated queue size will be 1 more than the
 	// supplied, so that when we push an entry and assign the

--- a/router/state.go
+++ b/router/state.go
@@ -129,8 +129,8 @@ func (s *state) _addPeer(conn net.Conn, public types.PublicKey, uri ConnectionUR
 			keepalives: keepalives,
 			context:    ctx,
 			cancel:     cancel,
-			proto:      newFIFOQueue(fifoNoMax),
-			traffic:    newFairFIFOQueue(queues),
+			proto:      newFIFOQueue(fifoNoMax, s.r.log),
+			traffic:    newFairFIFOQueue(queues, s.r.log),
 		}
 		s._peers[i] = new
 		s.r.log.Println("Connected to peer", new.public.String(), "on port", new.port)


### PR DESCRIPTION
Limit the number of sim ping workers to prevent overfilling peer traffic queues.