### PR TITLE
Remove pings from base protocol

### DIFF
--- a/cmd/pineconesim/simulator/adversary/drop_packets.go
+++ b/cmd/pineconesim/simulator/adversary/drop_packets.go
@@ -136,7 +136,7 @@ func (a *AdversaryRouter) Connect(conn net.Conn, options ...router.ConnectionOpt
 }
 
 func (a *AdversaryRouter) Ping(ctx context.Context, addr net.Addr) (uint16, time.Duration, error) {
-	return a.rtr.Ping(ctx, addr)
+	return 0, 0, nil
 }
 
 func (a *AdversaryRouter) Coords() types.Coordinates {

--- a/cmd/pineconesim/simulator/ping.go
+++ b/cmd/pineconesim/simulator/ping.go
@@ -1,0 +1,110 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simulator
+
+import (
+	"crypto/ed25519"
+	"encoding/binary"
+	"fmt"
+	"net"
+
+	"github.com/matrix-org/pinecone/types"
+)
+
+type PingType uint8
+
+const (
+	TreePing PingType = iota
+	TreePong
+	SNEKPing
+	SNEKPong
+)
+
+type PingPayload struct {
+	pingType    PingType
+	origin      net.Addr
+	destination net.Addr
+	hops        uint16
+}
+
+func (p *PingPayload) MarshalBinary(buffer []byte) (int, error) {
+	offset := 0
+	buffer[offset] = byte(p.pingType)
+	offset += 1
+	binary.BigEndian.PutUint16(buffer[offset:offset+2], p.hops)
+	offset += 2
+
+	switch orig := p.origin.(type) {
+	case types.Coordinates:
+		on, err := orig.MarshalBinary(buffer[offset:])
+		if err != nil {
+			return 0, fmt.Errorf("f.Destination.MarshalBinary: %w", err)
+		}
+		offset += on
+	case types.PublicKey:
+		offset += copy(buffer[offset:], orig[:ed25519.PublicKeySize])
+	}
+
+	switch dest := p.destination.(type) {
+	case types.Coordinates:
+		dn, err := dest.MarshalBinary(buffer[offset:])
+		if err != nil {
+			return 0, fmt.Errorf("f.Destination.MarshalBinary: %w", err)
+		}
+		offset += dn
+	case types.PublicKey:
+		offset += copy(buffer[offset:], dest[:ed25519.PublicKeySize])
+	}
+
+	return offset, nil
+}
+
+func (p *PingPayload) UnmarshalBinary(data []byte) (int, error) {
+	offset := 0
+	p.pingType = PingType(data[0])
+	p.hops = binary.BigEndian.Uint16(data[1:3])
+	offset += 3
+
+	switch p.pingType {
+	case TreePing, TreePong:
+		orig := types.Coordinates{}
+		oriLen, oriErr := orig.UnmarshalBinary(data[offset:])
+		if oriErr != nil {
+			return 0, fmt.Errorf("p.orig.UnmarshalBinary: %w", oriErr)
+		}
+		offset += oriLen
+		p.origin = net.Addr(orig)
+
+		dest := types.Coordinates{}
+		dstLen, dstErr := dest.UnmarshalBinary(data[offset:])
+		if dstErr != nil {
+			return 0, fmt.Errorf("p.dest.UnmarshalBinary: %w", dstErr)
+		}
+		offset += dstLen
+		p.destination = net.Addr(dest)
+	case SNEKPing, SNEKPong:
+		tempKey := types.PublicKey{}
+		offset += copy(tempKey[:], data[offset:])
+		p.origin = net.Addr(tempKey)
+
+		tempKey = types.PublicKey{}
+		offset += copy(tempKey[:], data[offset:])
+		p.destination = net.Addr(tempKey)
+	default:
+		return 0, fmt.Errorf("received invalid ping type")
+	}
+
+	return offset, nil
+}

--- a/cmd/pineconesim/simulator/router.go
+++ b/cmd/pineconesim/simulator/router.go
@@ -106,7 +106,7 @@ func (r *DefaultRouter) Ping(ctx context.Context, a net.Addr) (uint16, time.Dura
 		return 0, 0, fmt.Errorf("failed marshalling ping payload: %w", err)
 	}
 
-	_, writeErr := r.rtr.WriteTo(p, *nexthop)
+	_, writeErr := r.rtr.WriteTo(p, nexthop)
 	if writeErr != nil {
 		return 0, 0, fmt.Errorf("failed sending ping to node: %w", writeErr)
 	}
@@ -204,8 +204,8 @@ func (r *DefaultRouter) OverlayReadHandler(quit <-chan bool) {
 			continue
 		}
 
-		var fromAddr *net.Addr
-		fromAddr = &addr
+		var fromAddr net.Addr
+		fromAddr = addr
 		if payload.pingType == TreePing || payload.pingType == SNEKPing {
 			if !pingAtDest {
 				payload.hops++
@@ -224,7 +224,7 @@ func (r *DefaultRouter) OverlayReadHandler(quit <-chan bool) {
 			continue
 		}
 
-		var nexthop *net.Addr
+		var nexthop net.Addr
 		if payload.pingType == TreePing || payload.pingType == SNEKPing {
 			nexthop = r.rtr.NextHop(fromAddr, frameType, payload.destination)
 		} else {
@@ -234,7 +234,7 @@ func (r *DefaultRouter) OverlayReadHandler(quit <-chan bool) {
 			continue
 		}
 
-		_, writeErr := r.rtr.WriteTo(buf, *nexthop)
+		_, writeErr := r.rtr.WriteTo(buf, nexthop)
 		if writeErr != nil {
 			continue
 		}

--- a/cmd/pineconesim/simulator/router.go
+++ b/cmd/pineconesim/simulator/router.go
@@ -16,8 +16,10 @@ package simulator
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/matrix-org/pinecone/cmd/pineconesim/simulator/adversary"
@@ -38,7 +40,8 @@ type SimRouter interface {
 }
 
 type DefaultRouter struct {
-	rtr *router.Router
+	rtr   *router.Router
+	pings sync.Map // types.PublicKey -> chan struct{}
 }
 
 func (r *DefaultRouter) Subscribe(ch chan events.Event) {
@@ -53,10 +56,6 @@ func (r *DefaultRouter) Connect(conn net.Conn, options ...router.ConnectionOptio
 	return r.rtr.Connect(conn, options...)
 }
 
-func (r *DefaultRouter) Ping(ctx context.Context, a net.Addr) (uint16, time.Duration, error) {
-	return r.rtr.Ping(ctx, a)
-}
-
 func (r *DefaultRouter) Coords() types.Coordinates {
 	return r.rtr.Coords()
 }
@@ -67,4 +66,177 @@ func (r *DefaultRouter) ConfigureFilterPeer(peer types.PublicKey, rates adversar
 
 func (r *DefaultRouter) ManholeHandler(w http.ResponseWriter, req *http.Request) {
 	r.rtr.ManholeHandler(w, req)
+}
+
+func (r *DefaultRouter) Ping(ctx context.Context, a net.Addr) (uint16, time.Duration, error) {
+	id := a.String()
+
+	var origin net.Addr
+	var frameType types.FrameType
+	var pingType PingType
+
+	switch a.(type) {
+	case types.Coordinates:
+		origin = r.Coords()
+		frameType = types.TypeTreeRouted
+		pingType = TreePing
+	case types.PublicKey:
+		origin = r.PublicKey()
+		frameType = types.TypeVirtualSnakeRouted
+		pingType = SNEKPing
+	default:
+		return 0, 0, fmt.Errorf("invalid destination address")
+	}
+
+	payload := PingPayload{
+		pingType:    pingType,
+		origin:      origin,
+		destination: a,
+		hops:        1,
+	}
+
+	nexthop := r.rtr.NextHop(nil, frameType, a)
+	if nexthop == nil {
+		return 0, 0, fmt.Errorf("no valid nexthop for ping")
+	}
+
+	p := make([]byte, 256)
+	_, err := payload.MarshalBinary(p)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed marshalling ping payload: %w", err)
+	}
+
+	_, writeErr := r.rtr.WriteTo(p, *nexthop)
+	if writeErr != nil {
+		return 0, 0, fmt.Errorf("failed sending ping to node: %w", writeErr)
+	}
+
+	start := time.Now()
+	v, existing := r.pings.LoadOrStore(id, make(chan uint16))
+	if existing {
+		return 0, 0, fmt.Errorf("a ping to this node is already in progress")
+	}
+	defer r.pings.Delete(id)
+	ch := v.(chan uint16)
+	select {
+	case <-ctx.Done():
+		return 0, 0, fmt.Errorf("ping timed out")
+	case hops := <-ch:
+		return hops, time.Since(start), nil
+	}
+}
+
+func (r *DefaultRouter) OverlayReadHandler(quit <-chan bool) {
+	buf := make([]byte, 256)
+	for {
+		select {
+		case <-quit:
+			return
+		default:
+		}
+
+		_, addr, err := r.rtr.ReadFrom(buf)
+		if err != nil {
+			continue
+		}
+
+		payload := PingPayload{}
+		_, pingErr := payload.UnmarshalBinary(buf)
+		if pingErr != nil {
+			println(pingErr.Error())
+			continue
+		}
+
+		pingAtDest := false
+		var frameType types.FrameType
+		switch payload.pingType {
+		case TreePing:
+			switch dest := (payload.destination).(type) {
+			case types.Coordinates:
+				frameType = types.TypeTreeRouted
+				if dest.EqualTo(r.Coords()) {
+					pingAtDest = true
+				}
+			}
+		case TreePong:
+			switch orig := (payload.origin).(type) {
+			case types.Coordinates:
+				frameType = types.TypeTreeRouted
+				if orig.EqualTo(r.Coords()) {
+					id := payload.destination.String()
+					v, ok := r.pings.Load(id)
+					if !ok {
+						continue
+					}
+					ch := v.(chan uint16)
+					ch <- payload.hops
+					close(ch)
+					r.pings.Delete(id)
+					continue
+				}
+			}
+		case SNEKPing:
+			switch dest := (payload.destination).(type) {
+			case types.PublicKey:
+				frameType = types.TypeVirtualSnakeRouted
+				if dest == r.PublicKey() {
+					pingAtDest = true
+				}
+			}
+		case SNEKPong:
+			switch orig := (payload.origin).(type) {
+			case types.PublicKey:
+				frameType = types.TypeVirtualSnakeRouted
+				if orig == r.PublicKey() {
+					id := payload.destination.String()
+					v, ok := r.pings.Load(id)
+					if !ok {
+						continue
+					}
+					ch := v.(chan uint16)
+					ch <- payload.hops
+					close(ch)
+					r.pings.Delete(id)
+					continue
+				}
+			}
+		default:
+			continue
+		}
+
+		var fromAddr *net.Addr
+		fromAddr = &addr
+		if payload.pingType == TreePing || payload.pingType == SNEKPing {
+			if !pingAtDest {
+				payload.hops++
+			} else {
+				fromAddr = nil
+				if frameType == types.TypeTreeRouted {
+					payload.pingType = TreePong
+				} else {
+					payload.pingType = SNEKPong
+				}
+			}
+		}
+
+		_, pErr := payload.MarshalBinary(buf)
+		if pErr != nil {
+			continue
+		}
+
+		var nexthop *net.Addr
+		if payload.pingType == TreePing || payload.pingType == SNEKPing {
+			nexthop = r.rtr.NextHop(fromAddr, frameType, payload.destination)
+		} else {
+			nexthop = r.rtr.NextHop(fromAddr, frameType, payload.origin)
+		}
+		if nexthop == nil {
+			continue
+		}
+
+		_, writeErr := r.rtr.WriteTo(buf, *nexthop)
+		if writeErr != nil {
+			continue
+		}
+	}
 }

--- a/cmd/pineconesim/simulator/simulator.go
+++ b/cmd/pineconesim/simulator/simulator.go
@@ -61,7 +61,7 @@ func (r *EventSequenceRunner) Run(sim *Simulator) {
 	}
 }
 
-type RouterCreatorFn func(log *log.Logger, sk ed25519.PrivateKey, debug bool) SimRouter
+type RouterCreatorFn func(log *log.Logger, sk ed25519.PrivateKey, debug bool, quit <-chan bool) SimRouter
 
 type pair struct{ from, to string }
 

--- a/router/api.go
+++ b/router/api.go
@@ -18,11 +18,8 @@
 package router
 
 import (
-	"context"
 	"encoding/hex"
-	"fmt"
 	"net"
-	"time"
 
 	"github.com/Arceliar/phony"
 	"github.com/matrix-org/pinecone/router/events"
@@ -72,50 +69,46 @@ func (r *Router) Peers() []PeerInfo {
 	return infos
 }
 
-func (r *Router) Ping(ctx context.Context, a net.Addr) (uint16, time.Duration, error) {
-	id := a.String()
-	switch dst := a.(type) {
-	case types.PublicKey:
-		if dst == r.public {
-			return 0, 0, nil
-		}
+func (r *Router) NextHop(from *net.Addr, frameType types.FrameType, dest net.Addr) *net.Addr {
+	var fromPeer *peer
+	var nexthop *net.Addr
+	if from != nil {
 		phony.Block(r.state, func() {
-			frame := getFrame()
-			frame.Type = types.TypeSNEKPing
-			frame.DestinationKey = dst
-			frame.SourceKey = r.public
-			_ = r.state._forward(r.local, frame)
+			fromPeer = r.state._lookupPeer(*from)
 		})
 
-	case types.Coordinates:
-		if dst.EqualTo(r.state.coords()) {
-			return 0, 0, nil
+		if fromPeer == nil {
+			r.log.Println("could not find peer info for previous peer")
+			return nil
 		}
-		phony.Block(r.state, func() {
-			frame := getFrame()
-			frame.Type = types.TypeTreePing
-			frame.Destination = dst
-			frame.Source = r.state._coords()
-			_ = r.state._forward(r.local, frame)
-		})
+	}
 
-	default:
-		return 0, 0, &net.AddrError{
-			Err:  "unexpected address type",
-			Addr: a.String(),
+	var nextPeer *peer
+	phony.Block(r.state, func() {
+		nextPeer = r.state._nextHopsFor(fromPeer, frameType, dest)
+	})
+
+	if nextPeer != nil {
+		switch (dest).(type) {
+		case types.Coordinates:
+			var err error
+			coords := types.Coordinates{}
+			phony.Block(r.state, func() {
+				coords, err = nextPeer._coords()
+			})
+
+			if err != nil {
+				r.log.Println("failed retrieving coords for nexthop: %w", err)
+				return nil
+			}
+
+			coordsAddr := net.Addr(coords)
+			nexthop = &coordsAddr
+		case types.PublicKey:
+			key := net.Addr(nextPeer.public)
+			nexthop = &key
 		}
 	}
-	start := time.Now()
-	v, existing := r.pings.LoadOrStore(id, make(chan uint16))
-	if existing {
-		return 0, 0, fmt.Errorf("a ping to this node is already in progress")
-	}
-	defer r.pings.Delete(id)
-	ch := v.(chan uint16)
-	select {
-	case <-ctx.Done():
-		return 0, 0, fmt.Errorf("ping timed out")
-	case hops := <-ch:
-		return hops, time.Since(start), nil
-	}
+
+	return nexthop
 }

--- a/router/api.go
+++ b/router/api.go
@@ -74,7 +74,7 @@ func (r *Router) NextHop(from net.Addr, frameType types.FrameType, dest net.Addr
 	var nexthop net.Addr
 	if from != nil {
 		phony.Block(r.state, func() {
-			fromPeer = r.state._lookupPeer(from)
+			fromPeer = r.state._lookupPeerForAddr(from)
 		})
 
 		if fromPeer == nil {

--- a/router/api.go
+++ b/router/api.go
@@ -69,12 +69,12 @@ func (r *Router) Peers() []PeerInfo {
 	return infos
 }
 
-func (r *Router) NextHop(from *net.Addr, frameType types.FrameType, dest net.Addr) *net.Addr {
+func (r *Router) NextHop(from net.Addr, frameType types.FrameType, dest net.Addr) net.Addr {
 	var fromPeer *peer
-	var nexthop *net.Addr
+	var nexthop net.Addr
 	if from != nil {
 		phony.Block(r.state, func() {
-			fromPeer = r.state._lookupPeer(*from)
+			fromPeer = r.state._lookupPeer(from)
 		})
 
 		if fromPeer == nil {
@@ -98,15 +98,13 @@ func (r *Router) NextHop(from *net.Addr, frameType types.FrameType, dest net.Add
 			})
 
 			if err != nil {
-				r.log.Println("failed retrieving coords for nexthop: %w", err)
+				r.log.Println("failed retrieving coords for nexthop: %w")
 				return nil
 			}
 
-			coordsAddr := net.Addr(coords)
-			nexthop = &coordsAddr
+			nexthop = coords
 		case types.PublicKey:
-			key := net.Addr(nextPeer.public)
-			nexthop = &key
+			nexthop = nextPeer.public
 		}
 	}
 

--- a/router/packetconn.go
+++ b/router/packetconn.go
@@ -85,23 +85,23 @@ func (r *Router) WriteTo(p []byte, addr net.Addr) (n int, err error) {
 
 	switch ga := addr.(type) {
 	case types.Coordinates:
+		frame := getFrame()
+		frame.Type = types.TypeTreeRouted
+		frame.Destination = ga
+		frame.Source = r.state.coords()
+		frame.Payload = append(frame.Payload[:0], p...)
 		phony.Block(r.state, func() {
-			frame := getFrame()
-			frame.Type = types.TypeTreeRouted
-			frame.Destination = append(frame.Destination[:0], ga...)
-			frame.Source = append(frame.Source[:0], r.state.coords()...)
-			frame.Payload = append(frame.Payload[:0], p...)
 			_ = r.state._forward(r.local, frame)
 		})
 		return len(p), nil
 
 	case types.PublicKey:
+		frame := getFrame()
+		frame.Type = types.TypeVirtualSnakeRouted
+		frame.DestinationKey = ga
+		frame.SourceKey = r.public
+		frame.Payload = append(frame.Payload[:0], p...)
 		phony.Block(r.state, func() {
-			frame := getFrame()
-			frame.Type = types.TypeVirtualSnakeRouted
-			frame.DestinationKey = ga
-			frame.SourceKey = r.public
-			frame.Payload = append(frame.Payload[:0], p...)
 			_ = r.state._forward(r.local, frame)
 		})
 		return len(p), nil

--- a/router/peer.go
+++ b/router/peer.go
@@ -115,8 +115,6 @@ func (p *peer) send(f *types.Frame) bool {
 
 	// Traffic messages
 	case types.TypeVirtualSnakeRouted, types.TypeTreeRouted:
-		fallthrough
-	case types.TypeSNEKPing, types.TypeSNEKPong, types.TypeTreePing, types.TypeTreePong:
 		return p.traffic.push(f)
 	}
 
@@ -361,4 +359,18 @@ func (p *peer) _read() {
 	// This is effectively a recursive call to queue up the next read into
 	// the actor inbox.
 	p.reader.Act(nil, p._read)
+}
+
+func (p *peer) _coords() (types.Coordinates, error) {
+	var err error
+	coords := p.router.state._coords()
+	if p != p.router.local {
+		if announcement, ok := p.router.state._announcements[p]; ok {
+			coords = announcement.PeerCoords()
+		} else {
+			err = fmt.Errorf("no root announcement found for peer")
+		}
+	}
+
+	return coords, err
 }

--- a/router/peer.go
+++ b/router/peer.go
@@ -363,8 +363,11 @@ func (p *peer) _read() {
 
 func (p *peer) _coords() (types.Coordinates, error) {
 	var err error
-	coords := p.router.state._coords()
-	if p != p.router.local {
+	var coords types.Coordinates
+
+	if p == p.router.local {
+		coords = p.router.state._coords()
+	} else {
 		if announcement, ok := p.router.state._announcements[p]; ok {
 			coords = announcement.PeerCoords()
 		} else {

--- a/router/router.go
+++ b/router/router.go
@@ -46,7 +46,6 @@ type Router struct {
 	public       types.PublicKey
 	private      types.PrivateKey
 	active       sync.Map
-	pings        sync.Map // types.PublicKey -> chan struct{}
 	local        *peer
 	state        *state
 	secure       bool

--- a/router/state.go
+++ b/router/state.go
@@ -268,6 +268,8 @@ func (s *state) _portDisconnected(peer *peer) {
 	}
 }
 
+// _lookupPeerForAddr finds and returns the peer corresponding to the provided
+// net.Addr if such a peer exists.
 func (s *state) _lookupPeerForAddr(addr net.Addr) *peer {
 	var result *peer
 

--- a/router/state.go
+++ b/router/state.go
@@ -268,7 +268,7 @@ func (s *state) _portDisconnected(peer *peer) {
 	}
 }
 
-func (s *state) _lookupPeer(addr net.Addr) *peer {
+func (s *state) _lookupPeerForAddr(addr net.Addr) *peer {
 	var result *peer
 
 	for _, p := range s._peers {

--- a/router/state.go
+++ b/router/state.go
@@ -267,3 +267,29 @@ func (s *state) _portDisconnected(peer *peer) {
 		s._bootstrapNow()
 	}
 }
+
+func (s *state) _lookupPeer(addr net.Addr) *peer {
+	var result *peer
+
+	for _, p := range s._peers {
+		if p == nil || !p.started.Load() {
+			continue
+		}
+
+		switch fromAddr := addr.(type) {
+		case types.Coordinates:
+			coords, err := p._coords()
+			if err == nil && fromAddr.EqualTo(coords) {
+				result = p
+				break
+			}
+		case types.PublicKey:
+			if fromAddr == p.public {
+				result = p
+				break
+			}
+		}
+	}
+
+	return result
+}

--- a/router/state_forward.go
+++ b/router/state_forward.go
@@ -65,9 +65,9 @@ func (s *state) _forward(p *peer, f *types.Frame) error {
 	var nexthop *peer
 	switch f.Type {
 	case types.TypeTreeRouted, types.TypeVirtualSnakeBootstrapACK, types.TypeVirtualSnakeSetup:
-		nexthop = s._nextHopsFor(p, f.Type, net.Addr(f.Destination))
+		nexthop = s._nextHopsFor(p, f.Type, f.Destination)
 	case types.TypeVirtualSnakeBootstrap, types.TypeVirtualSnakeRouted, types.TypeVirtualSnakeTeardown:
-		nexthop = s._nextHopsFor(p, f.Type, net.Addr(f.DestinationKey))
+		nexthop = s._nextHopsFor(p, f.Type, f.DestinationKey)
 	}
 	deadend := nexthop == p.router.local
 

--- a/router/state_tree.go
+++ b/router/state_tree.go
@@ -193,9 +193,9 @@ type treeNextHopParams struct {
 // _nextHopsTree returns the best next-hop candidate for a given frame. The
 // "from" peer must be supplied in order to prevent routing loops. It is
 // possible for this function to return nil if no next best-hop is available.
-func (s *state) _nextHopsTree(from *peer, f *types.Frame) *peer {
+func (s *state) _nextHopsTree(from *peer, dest types.Coordinates) *peer {
 	nextHopParams := treeNextHopParams{
-		f.Destination,
+		dest,
 		s._coords(),
 		from,
 		s.r.local,

--- a/types/frame.go
+++ b/types/frame.go
@@ -43,10 +43,6 @@ const (
 	TypeVirtualSnakeSetupACK                      // protocol frame, forwarded using special rules
 	TypeVirtualSnakeTeardown                      // protocol frame, forwarded using special rules
 	TypeVirtualSnakeRouted                        // traffic frame, forwarded using SNEK
-	TypeSNEKPing                                  // traffic frame, forwarded using SNEK
-	TypeSNEKPong                                  // traffic frame, forwarded using SNEK
-	TypeTreePing                                  // traffic frame, forwarded using tree
-	TypeTreePong                                  // traffic frame, forwarded using tree
 )
 
 const (
@@ -156,7 +152,7 @@ func (f *Frame) MarshalBinary(buffer []byte) (int, error) {
 			offset += copy(buffer[offset:], f.Payload[:payloadLen])
 		}
 
-	case TypeVirtualSnakeRouted, TypeSNEKPing, TypeSNEKPong: // destination = key, source = key
+	case TypeVirtualSnakeRouted: // destination = key, source = key
 		payloadLen := len(f.Payload)
 		binary.BigEndian.PutUint16(buffer[offset+0:offset+2], uint16(payloadLen))
 		offset += 2
@@ -288,7 +284,7 @@ func (f *Frame) UnmarshalBinary(data []byte) (int, error) {
 		offset += copy(f.Payload, data[offset:])
 		return offset, nil
 
-	case TypeVirtualSnakeRouted, TypeSNEKPing, TypeSNEKPong: // destination = key, source = key
+	case TypeVirtualSnakeRouted: // destination = key, source = key
 		payloadLen := int(binary.BigEndian.Uint16(data[offset+0 : offset+2]))
 		if payloadLen > cap(f.Payload) {
 			return 0, fmt.Errorf("payload length exceeds frame capacity")
@@ -348,14 +344,6 @@ func (t FrameType) String() string {
 		return "VirtualSnakeTeardown"
 	case TypeKeepalive:
 		return "Keepalive"
-	case TypeSNEKPing:
-		return "SNEKPing"
-	case TypeSNEKPong:
-		return "SNEKPong"
-	case TypeTreePing:
-		return "TreePing"
-	case TypeTreePong:
-		return "TreePong"
 	default:
 		return "Unknown"
 	}


### PR DESCRIPTION
This pulls out the Tree & SNEK Ping/Pong frames from the protocol definition and moves their functionality into the simulator.