### PR TITLE
Fix logic for bootstrap payload protection

### DIFF
--- a/types/virtualsnake.go
+++ b/types/virtualsnake.go
@@ -22,17 +22,20 @@ func (a VirtualSnakeWatermark) WorseThan(b VirtualSnakeWatermark) bool {
 }
 
 func (v *VirtualSnakeBootstrap) ProtectedPayload() ([]byte, error) {
-	buffer := make([]byte, ed25519.SignatureSize+v.Sequence.Length())
-	sn, err := v.Sequence.MarshalBinary(buffer[:])
+	buffer := make([]byte, v.Sequence.Length()+v.Root.Length())
+	offset := 0
+	n, err := v.Sequence.MarshalBinary(buffer[:])
 	if err != nil {
 		return nil, fmt.Errorf("v.Sequence.MarshalBinary: %w", err)
 	}
-	rn := copy(buffer[:sn], v.RootPublicKey[:])
-	rsn, err := v.RootSequence.MarshalBinary(buffer[sn+rn:])
+	offset += n
+	offset += copy(buffer[offset:], v.RootPublicKey[:])
+	n, err = v.RootSequence.MarshalBinary(buffer[offset:])
 	if err != nil {
-		return nil, fmt.Errorf("v.Sequence.MarshalBinary: %w", err)
+		return nil, fmt.Errorf("v.RootSequence.MarshalBinary: %w", err)
 	}
-	return buffer[:sn+rn+rsn], nil
+	offset += n
+	return buffer[:offset], nil
 }
 
 func (v *VirtualSnakeBootstrap) MarshalBinary(buf []byte) (int, error) {


### PR DESCRIPTION
The buffer size was being calculated incorrectly.
Also the root public key was being copied into the buffer incorrectly.
Lastly, I changed to using an offset variable for buffer index tracking to be consistent with the rest of the code.