### PR TITLE
Do not log `net.ErrClosed` when stopping multicast

### DIFF
--- a/multicast/multicast.go
+++ b/multicast/multicast.go
@@ -19,6 +19,7 @@ import (
 	"crypto/ed25519"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -213,7 +214,9 @@ func (m *Multicast) accept(listener net.Listener) {
 	for {
 		conn, err := m.listener.Accept()
 		if err != nil {
-			m.log.Println("m.listener.Accept:", err)
+			if !errors.Is(err, net.ErrClosed) {
+				m.log.Println("m.listener.Accept:", err)
+			}
 			return
 		}
 


### PR DESCRIPTION
Just a tiny tweak. Currently stopping multicast with `Stop()` produces an ugly error log even though there is no error - the socket was closed as intended.

(This sent me on a bit of a wild goose chase, wondering why errors were being logged though everything seemed to be working fine, so hoping to avoid that in the future :P)

Signed-off-by: `0x1a8510f2 <admin@0x1a8510f2.space>`
