### PR TITLE
Don't respond to first announcement received from a peer

### DIFF
--- a/router/state_tree.go
+++ b/router/state_tree.go
@@ -303,12 +303,16 @@ func (s *state) _handleTreeAnnouncement(p *peer, f *types.Frame) error {
 		return fmt.Errorf("update sanity checks failed: %w", err)
 	}
 
+	isFirstAnnouncement := false
+
 	// If the peer is replaying an old sequence number to us then we
 	// assume that they are up to no good.
 	if ann := s._announcements[p]; ann != nil {
 		if newUpdate.RootPublicKey == ann.RootPublicKey && newUpdate.RootSequence < ann.RootSequence {
 			return fmt.Errorf("update replays old sequence number")
 		}
+	} else {
+		isFirstAnnouncement = true
 	}
 
 	// Get the key of our current root and then work out if the root
@@ -361,7 +365,9 @@ func (s *state) _handleTreeAnnouncement(p *peer, f *types.Frame) error {
 				})
 			})
 		case InformPeerOfStrongerRoot:
-			s.sendTreeAnnouncementToPeer(lastParentUpdate, p)
+			if !isFirstAnnouncement {
+				s.sendTreeAnnouncementToPeer(lastParentUpdate, p)
+			}
 		}
 	}
 


### PR DESCRIPTION
Since both nodes share their root annoucements when a new peering occurs, when the node with the higher root announcement responds to inform the node of a better root announcement what actually happens is one of the nodes receives two identical announcements and this prolongs the initial announcement handshake between two nodes. There are 7 announcements sent for each new peering in this case.

By not responding to a peer's first root announcement, this problem goes away resulting in a constant 3 announcements sent for each new peering. 