### PR TITLE
Support connecting to multiple other static peers in --connect

### DIFF
--- a/cmd/pinecone/main.go
+++ b/cmd/pinecone/main.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"net/http"
@@ -61,12 +62,14 @@ func main() {
 
 	listentcp := flag.String("listen", ":0", "address to listen for TCP connections")
 	listenws := flag.String("listenws", ":0", "address to listen for WebSockets connections")
-	connect := flag.String("connect", "", "peer to connect to")
+	connect := flag.String("connect", "", "peers to connect to")
 	manhole := flag.Bool("manhole", false, "enable the manhole (requires WebSocket listener to be active)")
 	flag.Parse()
 
 	if connect != nil && *connect != "" {
-		pineconeManager.AddPeer(*connect)
+		for _, uri := range strings.Split(*connect, ",") {
+			pineconeManager.AddPeer(strings.TrimSpace(uri))
+		}
 	}
 
 	if listenws != nil && *listenws != "" {


### PR DESCRIPTION
This pull request adds support for connecting to multiple other static peers by seperating each with a comma in the --connect argument.

Signed-off-by: Private sign-off
